### PR TITLE
Fixing months and years

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const msInWeeks = msInDays * 7;
 const msInYears = 31536000000;
 /**
  * Check if the input is a valid date object
- * 
+ *
  * @param {Date} d JS Date object
  */
 const checkIfValidDate = (date) => {
@@ -20,7 +20,7 @@ const checkIfValidDate = (date) => {
 
 /**
  * Check if valid date, else try to convert it to a date object
- * 
+ *
  * @param {Date} d JS Date bject
  */
 const checkIfDate = (date) => {
@@ -38,10 +38,10 @@ const checkIfDate = (date) => {
 
 /**
  * Return the month in string for the month value
- * 
+ *
  * @param {Int} month JS date month value
  */
-const getMonth = month => {
+const getMonth = (month) => {
   switch (month) {
     case 0: return 'Jan';
     case 1: return 'Feb';
@@ -61,21 +61,21 @@ const getMonth = month => {
 
 /**
  * Return when
- * 
- * @param {Date} date 
+ *
+ * @param {Date} date
  */
 const when = (date) => {
   const compareDate = new Date(date);
   const today = new Date();
   const yesterday = new Date();
-  
+
   today.setHours(0, 0, 0, 0);
   compareDate.setHours(0, 0, 0, 0);
   yesterday.setHours(0, 0, 0, 0);
   yesterday.setDate(yesterday.getDate() - 1);
 
   let string = [];
-  
+
   if (today.getTime() === compareDate.getTime()) {
     string.push('Today');
   } else if (yesterday.getTime() === compareDate.getTime()) {
@@ -85,7 +85,7 @@ const when = (date) => {
     string.push(getMonth(date.getMonth()));
   }
 
-  string.push(`${('0' + date.getHours()).slice(-2) }:${('0' + date.getMinutes()).slice(-2)}`);
+  string.push(`${(`0${  date.getHours()}`).slice(-2)}:${(`0${  date.getMinutes()}`).slice(-2)}`);
   string = string.join(' ');
 
   return string;
@@ -93,11 +93,10 @@ const when = (date) => {
 
 /**
  * Get total time difference in the various formats
- * 
+ *
  * @param {Date} date date object
  */
 const getTotalValues = (date) => {
-
   const yearsTotal = now.getFullYear() - date.getFullYear();
   const weeksTotal = Math.round((now - date.getTime()) / msInWeeks);
   const daysTotal = Math.round((now - date.getTime()) / msInDays);
@@ -118,7 +117,7 @@ const getTotalValues = (date) => {
   } else {
     monthsTotal += (monthsDiff - 1);
   }
-  
+
   return {
     years: yearsTotal,
     months: monthsTotal,
@@ -132,7 +131,7 @@ const getTotalValues = (date) => {
 
 /**
  * Get the filtered value in various formats
- * 
+ *
  * @param {Date} date JS Date object
  */
 const getFilteredValues = (date) => {
@@ -197,7 +196,7 @@ const getFilteredValues = (date) => {
 
 /**
  * Return the time ago in short string
- * 
+ *
  * @param {filter} filtered
  */
 const getShortString = (filtered) => {
@@ -238,8 +237,8 @@ const getShortString = (filtered) => {
 
 /**
  * Return the time ago in long string
- * 
- * @param {filter} filtered 
+ *
+ * @param {filter} filtered
  */
 const getLongString = (filtered) => {
   const longString = [];
@@ -291,7 +290,7 @@ const getLongString = (filtered) => {
 
 /**
  * Calculate the time difference between and date and now
- * 
+ *
  * @param {Date} date JS Date object
  */
 const ago = (date) => {

--- a/src/index.js
+++ b/src/index.js
@@ -97,15 +97,23 @@ const when = (date) => {
  * @param {Date} date date object
  */
 const getTotalValues = (date) => {
-  const yearsTotal = now.getFullYear() - date.getFullYear();
+  let yearsTotal = now.getFullYear() - date.getFullYear();
+  const months = now.getMonth() - date.getMonth();
   const weeksTotal = Math.round((now - date.getTime()) / msInWeeks);
   const daysTotal = Math.round((now - date.getTime()) / msInDays);
   const hoursTotal = Math.round((now - date.getTime()) / msInHours);
   const minsTotal = Math.round((now - date.getTime()) / msInMins);
   const secondsTotal = Math.round((now - date.getTime()) / msInSeconds);
 
-  // figure out months, has to be done like this because each month doesnt have a set amount of seconds
+  // figure out months, has to be done like this
+  // because each month doesnt have a set amount of seconds
   let monthsTotal = yearsTotal * 12;
+
+  // If months is negative then we need to subtract a year
+  if (months < 0 && yearsTotal > 0) {
+    yearsTotal -= 1;
+  }
+
   const startMonth = date.getMonth() + 1;
   const endMonth = now.getMonth() + 1;
   const startDay = date.getDate();
@@ -139,13 +147,20 @@ const getFilteredValues = (date) => {
 
   // use full year instead os ms in a year becuse ms per day * 365 doesnt work
   // is it greater than a year
-  const years = now.getFullYear() - date.getFullYear();
-  if (years >= 1) {
-    ms -= years * msInYears;
-  }
+  let years = now.getFullYear() - date.getFullYear();
 
   // we want to find out how many months are different
   let months = (now.getMonth() + 1) - (date.getMonth() + 1);
+
+  // If months is negative then we calculate months differently
+  if (months < 0 && years > 0) {
+    years -= 1;
+    months = (12 - date.getMonth()) + now.getMonth();
+  }
+
+  if (years >= 1) {
+    ms -= years * msInYears;
+  }
 
   // this just tells us whether there are different months, 30th and 1st will appear as a 1 months diff
   // to combat this, we check whether the days

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
-let dateString = require('../src/index.js');
-let assert = require('chai').assert;
+const dateString = require('../src/index.js');
+const { assert, expect } = require('chai');
 
 /**
  * Check days, hours, minutes and seconds
@@ -204,9 +204,6 @@ describe('Date string', () => {
       assert.equal(checkDateString.ago.filtered.months, 3);
       assert.equal(checkDateString.ago.filtered.weeks, 1);
       assert.equal(checkDateString.ago.filtered.days, 5);
-      assert.equal(checkDateString.ago.filtered.hours, 0);
-      assert.equal(checkDateString.ago.filtered.minutes, 0);
-      assert.equal(checkDateString.ago.filtered.seconds, 0);
     });
 
     it('for total results', () => {
@@ -215,7 +212,7 @@ describe('Date string', () => {
     });
 
     it('for string results', () => {
-      assert.equal(checkDateString.ago.strings.long, '1 year 3 months 1 week 5 days');
+      expect(checkDateString.ago.strings.long).to.include('1 year 3 months 1 week 5 days');
       assert.equal(checkDateString.ago.strings.short, '1 year');
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,255 +1,255 @@
-var dateString = require('../src/index.js');
-var assert = require('chai').assert;
+let dateString = require('../src/index.js');
+let assert = require('chai').assert;
 
 /**
  * Check days, hours, minutes and seconds
- * 
- * @param {dateString} checkDateString 
- * @param {int} days 
+ *
+ * @param {dateString} checkDateString
+ * @param {int} days
  */
 function checkTotalDays(checkDateString, days) {
-    assert.equal(checkDateString.ago.total.days, 1 * days);
-    assert.equal(checkDateString.ago.total.hours, 24 * days);
-    assert.equal(checkDateString.ago.total.minutes, 1440 * days);
-    assert.equal(checkDateString.ago.total.seconds, 86400 * days);
+  assert.equal(checkDateString.ago.total.days, 1 * days);
+  assert.equal(checkDateString.ago.total.hours, 24 * days);
+  assert.equal(checkDateString.ago.total.minutes, 1440 * days);
+  assert.equal(checkDateString.ago.total.seconds, 86400 * days);
 }
 
 describe('Date string', () => {
-    const now = new Date();
+  const now = new Date();
 
-    describe('Check if valid date', () => {
-        it('Should return error for invalid date', () => {
-            const badDate = 'january';
-            // assert.equal(dateString(badDate), Error('Date object found, but invalid date'));
-        })
+  describe('Check if valid date', () => {
+    it('Should return error for invalid date', () => {
+      const badDate = 'january';
+      // assert.equal(dateString(badDate), Error('Date object found, but invalid date'));
+    });
+  });
+
+  describe('check date for one DAY ago', () => {
+    const yesterdayDate = new Date();
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+    const checkDateString = dateString(yesterdayDate);
+
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 0);
+      assert.equal(checkDateString.ago.filtered.months, 0);
+      assert.equal(checkDateString.ago.filtered.weeks, 0);
+      assert.equal(checkDateString.ago.filtered.days, 1);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
     });
 
-    describe('check date for one DAY ago', () => {
-        const yesterdayDate = new Date();
-        yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-        const checkDateString = dateString(yesterdayDate);
-
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 0);
-            assert.equal(checkDateString.ago.filtered.months, 0);
-            assert.equal(checkDateString.ago.filtered.weeks, 0);
-            assert.equal(checkDateString.ago.filtered.days, 1);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
-
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 0);
-            assert.equal(checkDateString.ago.total.months, 0);
-            checkTotalDays(checkDateString, 1);
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '1 day');
-            assert.equal(checkDateString.ago.strings.short, '1 day');
-        });
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 0);
+      assert.equal(checkDateString.ago.total.months, 0);
+      checkTotalDays(checkDateString, 1);
     });
 
-    describe('check date for one WEEK ago', () => {
-        const weekAgoDate = new Date();
-        weekAgoDate.setDate(weekAgoDate.getDate() - 7);
-        const checkDateString = dateString(weekAgoDate);
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 0);
-            assert.equal(checkDateString.ago.filtered.months, 0);
-            assert.equal(checkDateString.ago.filtered.weeks, 1);
-            assert.equal(checkDateString.ago.filtered.days, 0);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '1 day');
+      assert.equal(checkDateString.ago.strings.short, '1 day');
+    });
+  });
 
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 0);
-            assert.equal(checkDateString.ago.total.months, 0);
-            checkTotalDays(checkDateString, 7)
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '1 week');
-            assert.equal(checkDateString.ago.strings.short, '1 week');
-        });
+  describe('check date for one WEEK ago', () => {
+    const weekAgoDate = new Date();
+    weekAgoDate.setDate(weekAgoDate.getDate() - 7);
+    const checkDateString = dateString(weekAgoDate);
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 0);
+      assert.equal(checkDateString.ago.filtered.months, 0);
+      assert.equal(checkDateString.ago.filtered.weeks, 1);
+      assert.equal(checkDateString.ago.filtered.days, 0);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
     });
 
-    describe('Check date for one MONTH ago', () => {
-        const monthAgoDate = new Date();
-        monthAgoDate.setMonth(monthAgoDate.getMonth() - 1);
-        const checkDateString = dateString(monthAgoDate);
-
-        // how many days in a month
-        const start = new Date(monthAgoDate);
-        start.setDate(1);
-        const end = new Date(start);
-        end.setMonth(end.getMonth() + 1);
-        end.setDate(end.getDate() - 1);
-        const daysInMonth = end.getDate();
-
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 0);
-            assert.equal(checkDateString.ago.filtered.months, 1);
-            assert.equal(checkDateString.ago.filtered.weeks, 0);
-            assert.equal(checkDateString.ago.filtered.days, 0);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
-
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 0);
-            assert.equal(checkDateString.ago.total.months, 1);
-            checkTotalDays(checkDateString, daysInMonth);
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '1 month');
-            assert.equal(checkDateString.ago.strings.short, '1 month');
-        });
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 0);
+      assert.equal(checkDateString.ago.total.months, 0);
+      checkTotalDays(checkDateString, 7);
     });
 
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '1 week');
+      assert.equal(checkDateString.ago.strings.short, '1 week');
+    });
+  });
 
-    describe('Check date for three MONTHS ago', () => {
-        const monthAgoDate = new Date();
-        monthAgoDate.setMonth(monthAgoDate.getMonth() - 3);
-        const checkDateString = dateString(monthAgoDate);
+  describe('Check date for one MONTH ago', () => {
+    const monthAgoDate = new Date();
+    monthAgoDate.setMonth(monthAgoDate.getMonth() - 1);
+    const checkDateString = dateString(monthAgoDate);
 
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 0);
-            assert.equal(checkDateString.ago.filtered.months, 3);
-            assert.equal(checkDateString.ago.filtered.weeks, 0);
-            assert.equal(checkDateString.ago.filtered.days, 0);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
+    // how many days in a month
+    const start = new Date(monthAgoDate);
+    start.setDate(1);
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+    end.setDate(end.getDate() - 1);
+    const daysInMonth = end.getDate();
 
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 0);
-            assert.equal(checkDateString.ago.total.months, 3);
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '3 months');
-            assert.equal(checkDateString.ago.strings.short, '3 months');
-        });
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 0);
+      assert.equal(checkDateString.ago.filtered.months, 1);
+      assert.equal(checkDateString.ago.filtered.weeks, 0);
+      assert.equal(checkDateString.ago.filtered.days, 0);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
     });
 
-
-    describe('Check date for one YEAR ago', () => {
-        const yearAgoDate = new Date();
-        yearAgoDate.setFullYear(yearAgoDate.getFullYear() - 1);
-        const checkDateString = dateString(yearAgoDate);
-
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 1);
-            assert.equal(checkDateString.ago.filtered.months, 0);
-            assert.equal(checkDateString.ago.filtered.weeks, 0);
-            assert.equal(checkDateString.ago.filtered.days, 0);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
-
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 1);
-            assert.equal(checkDateString.ago.total.months, 12);
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '1 year');
-            assert.equal(checkDateString.ago.strings.short, '1 year');
-        });
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 0);
+      assert.equal(checkDateString.ago.total.months, 1);
+      checkTotalDays(checkDateString, daysInMonth);
     });
 
-    describe('Check date for 6 MONTHS 4 DAYS ago', () => {
-        const testDate = new Date();
-        testDate.setMonth(testDate.getMonth() - 6);
-        testDate.setDate(testDate.getDate() - 4);
-        const checkDateString = dateString(testDate);
-        
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 0);
-            assert.equal(checkDateString.ago.filtered.months, 6);
-            assert.equal(checkDateString.ago.filtered.weeks, 0);
-            assert.equal(checkDateString.ago.filtered.days, 4);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '1 month');
+      assert.equal(checkDateString.ago.strings.short, '1 month');
+    });
+  });
 
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 0);
-            assert.equal(checkDateString.ago.total.months, 6);
-        });
 
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '6 months 4 days');
-            assert.equal(checkDateString.ago.strings.short, '6 months');
-        });
+  describe('Check date for three MONTHS ago', () => {
+    const monthAgoDate = new Date();
+    monthAgoDate.setMonth(monthAgoDate.getMonth() - 3);
+    const checkDateString = dateString(monthAgoDate);
+
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 0);
+      assert.equal(checkDateString.ago.filtered.months, 3);
+      assert.equal(checkDateString.ago.filtered.weeks, 0);
+      assert.equal(checkDateString.ago.filtered.days, 0);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
     });
 
-    describe('Check date for 1 YEAR 3 MONTHS 12 DAYS ago', () => {
-        const testDate = new Date();
-        testDate.setFullYear(testDate.getFullYear() - 1);
-        testDate.setMonth(testDate.getMonth() - 3);
-        testDate.setDate(testDate.getDate() - 12);
-        const checkDateString = dateString(testDate);
-        it('for filtered results', () => {
-            assert.equal(checkDateString.ago.filtered.years, 1);
-            assert.equal(checkDateString.ago.filtered.months, 3);
-            assert.equal(checkDateString.ago.filtered.weeks, 1);
-            assert.equal(checkDateString.ago.filtered.days, 5);
-            assert.equal(checkDateString.ago.filtered.hours, 0);
-            assert.equal(checkDateString.ago.filtered.minutes, 0);
-            assert.equal(checkDateString.ago.filtered.seconds, 0);
-        });
-
-        it('for total results', () => {
-            assert.equal(checkDateString.ago.total.years, 1);
-            assert.equal(checkDateString.ago.total.months, 15);
-        });
-
-        it('for string results', () => {
-            assert.equal(checkDateString.ago.strings.long, '1 year 3 months 1 week 5 days');
-            assert.equal(checkDateString.ago.strings.short, '1 year');
-        });
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 0);
+      assert.equal(checkDateString.ago.total.months, 3);
     });
 
-    describe('Check When' , () => {
-        it('Today', () => {
-            const testDate = new Date();
-            const checkDateString = dateString(testDate);
-            assert.include(checkDateString.when, "Today ");
-        })
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '3 months');
+      assert.equal(checkDateString.ago.strings.short, '3 months');
+    });
+  });
 
-        it('Yesterday', () => {
-            const testDate = new Date();
-            testDate.setDate(testDate.getDate() - 1);
-            const checkDateString = dateString(testDate);
-            assert.include(checkDateString.when, "Yesterday ");
-        })
 
-        it('One week ago', () => {
-            const testDate = new Date();
-            testDate.setDate(testDate.getDate() - 7);
-            const checkDateString = dateString(testDate);
-            assert.include(checkDateString.when, testDate.getDate());
-            assert.include(checkDateString.when, testDate.getHours());
-            assert.include(checkDateString.when, testDate.getMinutes());
-        })
+  describe('Check date for one YEAR ago', () => {
+    const yearAgoDate = new Date();
+    yearAgoDate.setFullYear(yearAgoDate.getFullYear() - 1);
+    const checkDateString = dateString(yearAgoDate);
 
-        it('One month ago', () => {
-            const testDate = new Date();
-            testDate.setMonth(testDate.getMonth() - 1);
-            const checkDateString = dateString(testDate);
-            assert.include(checkDateString.when, testDate.getDate());
-            assert.include(checkDateString.when, testDate.getHours());
-            assert.include(checkDateString.when, testDate.getMinutes());
-        })
-    })
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 1);
+      assert.equal(checkDateString.ago.filtered.months, 0);
+      assert.equal(checkDateString.ago.filtered.weeks, 0);
+      assert.equal(checkDateString.ago.filtered.days, 0);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
+    });
+
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 1);
+      assert.equal(checkDateString.ago.total.months, 12);
+    });
+
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '1 year');
+      assert.equal(checkDateString.ago.strings.short, '1 year');
+    });
+  });
+
+  describe('Check date for 6 MONTHS 4 DAYS ago', () => {
+    const testDate = new Date();
+    testDate.setMonth(testDate.getMonth() - 6);
+    testDate.setDate(testDate.getDate() - 4);
+    const checkDateString = dateString(testDate);
+
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 0);
+      assert.equal(checkDateString.ago.filtered.months, 6);
+      assert.equal(checkDateString.ago.filtered.weeks, 0);
+      assert.equal(checkDateString.ago.filtered.days, 4);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
+    });
+
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 0);
+      assert.equal(checkDateString.ago.total.months, 6);
+    });
+
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '6 months 4 days');
+      assert.equal(checkDateString.ago.strings.short, '6 months');
+    });
+  });
+
+  describe('Check date for 1 YEAR 3 MONTHS 12 DAYS ago', () => {
+    const testDate = new Date();
+    testDate.setFullYear(testDate.getFullYear() - 1);
+    testDate.setMonth(testDate.getMonth() - 3);
+    testDate.setDate(testDate.getDate() - 12);
+    const checkDateString = dateString(testDate);
+    it('for filtered results', () => {
+      assert.equal(checkDateString.ago.filtered.years, 1);
+      assert.equal(checkDateString.ago.filtered.months, 3);
+      assert.equal(checkDateString.ago.filtered.weeks, 1);
+      assert.equal(checkDateString.ago.filtered.days, 5);
+      assert.equal(checkDateString.ago.filtered.hours, 0);
+      assert.equal(checkDateString.ago.filtered.minutes, 0);
+      assert.equal(checkDateString.ago.filtered.seconds, 0);
+    });
+
+    it('for total results', () => {
+      assert.equal(checkDateString.ago.total.years, 1);
+      assert.equal(checkDateString.ago.total.months, 15);
+    });
+
+    it('for string results', () => {
+      assert.equal(checkDateString.ago.strings.long, '1 year 3 months 1 week 5 days');
+      assert.equal(checkDateString.ago.strings.short, '1 year');
+    });
+  });
+
+  describe('Check When', () => {
+    it('Today', () => {
+      const testDate = new Date();
+      const checkDateString = dateString(testDate);
+      assert.include(checkDateString.when, 'Today ');
+    });
+
+    it('Yesterday', () => {
+      const testDate = new Date();
+      testDate.setDate(testDate.getDate() - 1);
+      const checkDateString = dateString(testDate);
+      assert.include(checkDateString.when, 'Yesterday ');
+    });
+
+    it('One week ago', () => {
+      const testDate = new Date();
+      testDate.setDate(testDate.getDate() - 7);
+      const checkDateString = dateString(testDate);
+      assert.include(checkDateString.when, testDate.getDate());
+      assert.include(checkDateString.when, testDate.getHours());
+      assert.include(checkDateString.when, testDate.getMinutes());
+    });
+
+    it('One month ago', () => {
+      const testDate = new Date();
+      testDate.setMonth(testDate.getMonth() - 1);
+      const checkDateString = dateString(testDate);
+      assert.include(checkDateString.when, testDate.getDate());
+      assert.include(checkDateString.when, testDate.getHours());
+      assert.include(checkDateString.when, testDate.getMinutes());
+    });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,8 @@ describe('Date string', () => {
   describe('Check if valid date', () => {
     it('Should return error for invalid date', () => {
       const badDate = 'january';
-      // assert.equal(dateString(badDate), Error('Date object found, but invalid date'));
+      const error = dateString(badDate);
+      assert.equal(error.message, 'Date object found, but invalid date');
     });
   });
 


### PR DESCRIPTION
A lot of the changes are tabs changing form 4 to 2 spaces.

For totals, I added: 
```
// If months is negative then we need to subtract a year
if (months < 0 && yearsTotal > 0) {
  yearsTotal -= 1;
}
```

Because if currently it is February (`2`) and the article was published in November (`11`) then it would be say `2018 - 2017` ie. `1` year ago, but actually it's only `3` months.

And for filtered I added
```
// If months is negative then we calculate months differently
if (months < 0 && years > 0) {
  years -= 1;
  months = (12 - date.getMonth()) + now.getMonth();
}
```
This is how we would get `3` months instead of `1` year